### PR TITLE
Support for setting core ssh keys.

### DIFF
--- a/modules/node-ignition/main.tf
+++ b/modules/node-ignition/main.tf
@@ -65,6 +65,11 @@ data "ignition_systemd_unit" "kontena_agent" {
   content = "${file("${path.module}/systemd/kontena-agent.service")}"
 }
 
+data "ignition_user" "core" {
+  name                = "core"
+  ssh_authorized_keys = "${var.authorized_keys_core}"
+}
+
 data "ignition_config" "default" {
   systemd = [
     "${data.ignition_systemd_unit.kontena_dropin.id}",
@@ -79,5 +84,9 @@ data "ignition_config" "default" {
 
   files = [
     "${data.ignition_file.kontena_agent.id}",
+  ]
+
+  users = [
+    "${data.ignition_user.core.id}",
   ]
 }

--- a/modules/node-ignition/variables.tf
+++ b/modules/node-ignition/variables.tf
@@ -34,3 +34,8 @@ variable "overlay_version" {
   description = "Docker overlay version"
   default     = "overlay2"
 }
+
+variable "authorized_keys_core" {
+  description = "Authorized SSH keys for the user core"
+  default     = []
+}


### PR DESCRIPTION
```
authorized_keys_core = [
    "ssh-rsa AAAAB3Nza....",
    "ssh-rsa AAAAB3Nzb....",
  ]
```